### PR TITLE
hotfix: avoid divided by 0

### DIFF
--- a/mellowmax_softmax/scripts/random_mdp_exp.py
+++ b/mellowmax_softmax/scripts/random_mdp_exp.py
@@ -71,7 +71,8 @@ def test_termination(softmax):
                 idx = np.argmax(gvi.Q[s])
                 q_max.append(np.unravel_index(idx, gvi.Q[s].shape))
 
-        avg_iter /= (ITERATION - no_term)
+        valid_iter = ITERATION - no_term
+        avg_iter = avg_iter / valid_iter if valid_iter > 0 else 0
 
         if q_max not in fixed_points or len(fixed_points) == 0:
             fixed_points.append(q_max)


### PR DESCRIPTION
# Description
When a random MDP is not able to converge (iteration >= 1000), the `avg_iter` (`random_mdp_exp:74`) might be divided by 0. It may occur is because when it fails to converge whenever doing policy iteration, the `no_term` will be equal to `ITERATION` (`random_mdp_exp:74`).

# Changes
- When the `no_term == ITERATION`, set `avg_iter` to 0